### PR TITLE
Remove submodule support from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: true
           show-progress: false
 
       - name: Configure


### PR DESCRIPTION
We don't have any and it slows down testing marginally