### PR TITLE
Minimizing the clang-tidy exception list

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,33 +1,17 @@
 ---
 Checks:
   - "*"
-  - "-abseil-*"
-  - "-altera-*"
-  - "-android-*"
-  - "-cppcoreguidelines-avoid-magic-numbers"
-  - "-cppcoreguidelines-non-private-member-variables-in-classes"
-  - "-cppcoreguidelines-pro-type-vararg"
-  - "-fuchsia-*"
-  - "-google-*"
-  - "-hicpp-vararg"
-  - "-llvm*"
-  - "-misc-non-private-member-variables-in-classes"
-  - "-modernize-use-trailing-return-type"
-  - "-readability-avoid-const-params-in-decls"
-  - "-readability-else-after-return"
-  - "-readability-function-cognitive-complexity"
-  - "-readability-identifier-length"
-  - "-readability-magic-numbers"
-  - "-readability-static-accessed-through-instance"
-  - "-zircon-*"
+  - "-altera-unroll-loops" # Required for gtest
+  - "-fuchsia-*" # Internal Zircon https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx
+  - "-llvmlibc-*" # Internal llvm libc flags
+  - "-readability-function-cognitive-complexity" # Required for gtest
 
 WarningsAsErrors: ""
 HeaderFilterRegex: ""
 FormatStyle: none
-
-CheckOptions:
-  - key: readability-identifier-length.IgnoredVariableNames
-    value: "x|y|z"
+# CheckOptions:
+#   - key: readability-identifier-length.IgnoredVariableNames
+#     value: "x|y|z"
 # Local Variables:
 # mode: yaml
 # End:

--- a/README.md
+++ b/README.md
@@ -233,10 +233,10 @@ strings, or be left undefined, in which case it defaults to `verbose`.
   of checking in a program.
 
 - `ADOBE_CONTRACT_VIOLATION=custom_verbose`: When a contract violation is detected, a custom handler
-  is invoked. The client must define the handler at global scope with the signature:
+  is invoked. The client must define the handler in the `adobe` namespace with the signature:
 
   ```cpp
-  [[noreturn]] void adobe_contract_violation_verbose(const char *condition,
+  [[noreturn]] void ::adobe::contract_violated_verbose(const char *condition,
     adobe::contract_violation_kind kind, const char *file, std::uint32_t line,
     const char *message) {
       // implementation
@@ -250,10 +250,10 @@ strings, or be left undefined, in which case it defaults to `verbose`.
   application, and must not return to its caller.
 
 - `ADOBE_CONTRACT_VIOLATION=custom_lightweight`: When a contract violation is detected, a custom
-  handler is invoked. The client must define the handler at global scope with the signature:
+  handler is invoked. The client must define the handler in the `adobe` namespace with the signature:
 
   ```cpp
-  [[noreturn]] void adobe_contract_violation_lightweight() {
+  [[noreturn]] void ::adobe::contract_violated_lightweight() {
       // implementation
   }
   ```

--- a/include/adobe/contract_checks.hpp
+++ b/include/adobe/contract_checks.hpp
@@ -185,9 +185,9 @@ static_assert(false,
 //
 // Expands to a statement that reports a contract violation of the
 // given kind (with <message>, if supplied) when <condition> is false.
-#define ADOBE_CONTRACT_CHECK(kind, ...)                                 \
-  INTERNAL_ADOBE_MSVC_EXPAND(INTERNAL_ADOBE_THIRD_ARGUMENT(__VA_ARGS__, \
-    INTERNAL_ADOBE_CONTRACT_CHECK_2,                                    \
-    INTERNAL_ADOBE_CONTRACT_CHECK_1)(kind, __VA_ARGS__))
+#define ADOBE_CONTRACT_CHECK(kind, ...)                                                      \
+  INTERNAL_ADOBE_MSVC_EXPAND(INTERNAL_ADOBE_THIRD_ARGUMENT(                                  \
+    __VA_ARGS__, INTERNAL_ADOBE_CONTRACT_CHECK_2, INTERNAL_ADOBE_CONTRACT_CHECK_1, ignored)( \
+    kind, __VA_ARGS__))
 
 #endif

--- a/include/adobe/contract_checks.hpp
+++ b/include/adobe/contract_checks.hpp
@@ -94,23 +94,27 @@ namespace detail {
 #elif INTERNAL_ADOBE_CONTRACT_VIOLATION_BEHAVIOR == INTERNAL_ADOBE_CONTRACT_VIOLATION_custom_verbose
 
 #define INTERNAL_ADOBE_CONTRACT_VIOLATED(condition, kind, file, line, message) \
-  ::adobe_contract_violated_verbose(condition, kind, file, line, message)
+  ::adobe::contract_violated_verbose(condition, kind, file, line, message)
 
 #include <cstdint>
 
-[[noreturn]] extern void adobe_contract_violated_verbose(const char *condition,
+namespace adobe {
+[[noreturn]] extern void contract_violated_verbose(const char *condition,
   adobe::contract_violation_kind kind,
   const char *file,
   std::uint32_t line,
   const char *message);
+}
 
 #elif INTERNAL_ADOBE_CONTRACT_VIOLATION_BEHAVIOR \
   == INTERNAL_ADOBE_CONTRACT_VIOLATION_custom_lightweight
 
 #define INTERNAL_ADOBE_CONTRACT_VIOLATED(condition, kind, file, line, message) \
-  ::adobe_contract_violated_lightweight()
+  ::adobe::contract_violated_lightweight()
 
-[[noreturn]] extern void adobe_contract_violated_lightweight();
+namespace adobe {
+[[noreturn]] extern void contract_violated_lightweight();
+}
 
 #elif INTERNAL_ADOBE_CONTRACT_VIOLATION_BEHAVIOR == INTERNAL_ADOBE_CONTRACT_VIOLATION_unsafe
 
@@ -181,9 +185,9 @@ static_assert(false,
 //
 // Expands to a statement that reports a contract violation of the
 // given kind (with <message>, if supplied) when <condition> is false.
-#define ADOBE_CONTRACT_CHECK(kind, ...)                                                      \
-  INTERNAL_ADOBE_MSVC_EXPAND(INTERNAL_ADOBE_THIRD_ARGUMENT(                                  \
-    __VA_ARGS__, INTERNAL_ADOBE_CONTRACT_CHECK_2, INTERNAL_ADOBE_CONTRACT_CHECK_1, ignored)( \
-    kind, __VA_ARGS__))
+#define ADOBE_CONTRACT_CHECK(kind, ...)                                 \
+  INTERNAL_ADOBE_MSVC_EXPAND(INTERNAL_ADOBE_THIRD_ARGUMENT(__VA_ARGS__, \
+    INTERNAL_ADOBE_CONTRACT_CHECK_2,                                    \
+    INTERNAL_ADOBE_CONTRACT_CHECK_1)(kind, __VA_ARGS__))
 
 #endif

--- a/test/custom_lightweight_configuration_tests.cpp
+++ b/test/custom_lightweight_configuration_tests.cpp
@@ -13,8 +13,8 @@ TEST(CustomLightweightConfiguration, FailedChecksThrow)
   EXPECT_THROW(ADOBE_PRECONDITION(false), std::logic_error);
   EXPECT_THROW(ADOBE_INVARIANT(false), std::logic_error);
 
-  EXPECT_THROW(ADOBE_PRECONDITION(false, "##########"), std::logic_error);
-  EXPECT_THROW(ADOBE_INVARIANT(false, "#########"), std::logic_error);
+  EXPECT_THROW(ADOBE_PRECONDITION(false, "% Message %"), std::logic_error);
+  EXPECT_THROW(ADOBE_INVARIANT(false, "% Message %"), std::logic_error);
 }
 
 TEST(CustomLightweightConfiguration, ContractNonViolationsDoNotThrow)
@@ -22,6 +22,6 @@ TEST(CustomLightweightConfiguration, ContractNonViolationsDoNotThrow)
   ADOBE_PRECONDITION(true);
   ADOBE_INVARIANT(true);
 
-  ADOBE_PRECONDITION(true, "##########");
-  ADOBE_INVARIANT(true, "#########");
+  ADOBE_PRECONDITION(true, "% Message %");
+  ADOBE_INVARIANT(true, "% Message %");
 }

--- a/test/custom_lightweight_configuration_tests.cpp
+++ b/test/custom_lightweight_configuration_tests.cpp
@@ -3,9 +3,9 @@
 #include <gtest/gtest.h>
 #include <stdexcept>
 
-[[noreturn]] void adobe_contract_violated_lightweight()
+[[noreturn]] void ::adobe::contract_violated_lightweight()
 {
-  throw std::logic_error("adobe_contract_violated_lightweight");
+  throw std::logic_error("::adobe::contract_violated_lightweight");
 }
 
 TEST(CustomLightweightConfiguration, FailedChecksThrow)

--- a/test/custom_verbose_configuration_tests.cpp
+++ b/test/custom_verbose_configuration_tests.cpp
@@ -1,21 +1,26 @@
 #include "adobe/contract_checks.hpp"
+
 #include "portable_death_tests.hpp"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include <array>
 #include <cstdint>
 #include <cstdio>
 #include <exception>
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include <stdexcept>
 
 // Throws a std::logic_error with a message constructed from the arguments.
-[[noreturn]] void adobe_contract_violated_verbose(const char *condition,
+[[noreturn]] void ::adobe::contract_violated_verbose(const char *condition,
   adobe::contract_violation_kind kind,
   const char *file,
   std::uint32_t line,
   const char *message)
 {
-  std::array<char, 1024> output{};
+  constexpr std::size_t max_output_size = 1024;
+  std::array<char, max_output_size> output{};
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, hicpp-vararg)
   (void)std::snprintf(output.data(),
     sizeof(output),
     "%s:%d: %s (%s). %s\n",
@@ -30,12 +35,12 @@
 
 namespace {
 
-// Expects that `f()` throws an exception and that the exception's `what()` method contains the
+// Expects that `fun()` throws an exception and that the exception's `what()` method contains the
 // `match` regex.
-template<class F> void expect_throw(F f, const char *match)
+template<class F> void expect_throw(F fun, const char *match)
 {
   try {
-    f();
+    fun();
   } catch (const std::exception &e) {
     EXPECT_THAT(e.what(), testing::ContainsRegex(match));
     return;

--- a/test/custom_verbose_configuration_tests.cpp
+++ b/test/custom_verbose_configuration_tests.cpp
@@ -5,9 +5,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <array>
 #include <cstdint>
 #include <exception>
+#include <sstream>
 #include <stdexcept>
 
 // Throws a std::logic_error with a message constructed from the arguments.

--- a/test/custom_verbose_configuration_tests.cpp
+++ b/test/custom_verbose_configuration_tests.cpp
@@ -18,19 +18,13 @@
   std::uint32_t line,
   const char *message)
 {
-  constexpr std::size_t max_output_size = 1024;
-  std::array<char, max_output_size> output{};
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, hicpp-vararg)
-  (void)std::snprintf(output.data(),
-    sizeof(output),
-    "%s:%d: %s (%s). %s\n",
-    file,
-    static_cast<int>(line),
-    kind == adobe::contract_violation_kind::precondition ? "Precondition violated"
-                                                         : "Invariant not upheld",
-    condition,
-    message);
-  throw std::logic_error(output.data());
+  throw std::logic_error{ (std::ostringstream{}
+                           << file << ":" << line << ": "
+                           << (kind == adobe::contract_violation_kind::precondition
+                                  ? "Precondition violated"
+                                  : "Invariant not upheld")
+                           << " (" << condition << "). " << message << "\n")
+      .str() };
 }
 
 namespace {

--- a/test/inadequate_arity_checking_tests.cpp
+++ b/test/inadequate_arity_checking_tests.cpp
@@ -1,7 +1,9 @@
 #include "adobe/contract_checks.hpp"
 #include <gtest/gtest.h>
 
-struct F
+namespace {
+
+struct Failure
 {
   template<class T, class U, class V, class W>
   void operator()(const T & /*unused*/,
@@ -10,12 +12,15 @@ struct F
     const W & /*unused*/) const
   {}
 };
-const F f;
+
+const Failure failure;
+
+}// namespace
 
 TEST(ArityChecking, TooManyArgumentsNotAlwaysDetected)
 {
   // These don't fail, so our arity detection is weak.
   // https://github.com/stlab/adobe-contract-checks/issues/19
-  ADOBE_PRECONDITION(true, "message", f);
-  ADOBE_INVARIANT(true, "message", f);
+  ADOBE_PRECONDITION(true, "message", failure);
+  ADOBE_INVARIANT(true, "message", failure);
 }

--- a/test/lightweight_configuration_tests.cpp
+++ b/test/lightweight_configuration_tests.cpp
@@ -31,8 +31,8 @@ TEST(LightweightConfiguration, ContractNonViolationsDoNotCauseAbort)
   ADOBE_PRECONDITION(true);
   ADOBE_INVARIANT(true);
 
-  ADOBE_PRECONDITION(true, "##########");
-  ADOBE_INVARIANT(true, "#########");
+  ADOBE_PRECONDITION(true, "% Message %"");
+  ADOBE_INVARIANT(true, "% Message %");
 }
 
 #if defined(__EMSCRIPTEN__) && 0

--- a/test/lightweight_configuration_tests.cpp
+++ b/test/lightweight_configuration_tests.cpp
@@ -31,7 +31,7 @@ TEST(LightweightConfiguration, ContractNonViolationsDoNotCauseAbort)
   ADOBE_PRECONDITION(true);
   ADOBE_INVARIANT(true);
 
-  ADOBE_PRECONDITION(true, "% Message %"");
+  ADOBE_PRECONDITION(true, "% Message %");
   ADOBE_INVARIANT(true, "% Message %");
 }
 

--- a/test/verbose_configuration_tests.cpp
+++ b/test/verbose_configuration_tests.cpp
@@ -13,6 +13,7 @@ TEST(VerboseConfigurationDeathTest, ContractViolationsCauseAbort)
   EXPECT_ABORT(ADOBE_INVARIANT(false), "");
 }
 
+// LINE_STRING turns __LINE__ into a string literal.
 #define STRINGIZE(x) STRINGIZE2(x)// NOLINT(cppcoreguidelines-macro-usage)
 #define STRINGIZE2(x) #x// NOLINT(cppcoreguidelines-macro-usage)
 #define LINE_STRING STRINGIZE(__LINE__)// NOLINT(cppcoreguidelines-macro-usage)


### PR DESCRIPTION
Enabled all clang-tidy checks except:
- Those required to compile with gtest
- Those used to validate restricted language subsets for specialized purposes